### PR TITLE
Revert failed build updates

### DIFF
--- a/.github/workflows/ada.yml
+++ b/.github/workflows/ada.yml
@@ -19,12 +19,12 @@ jobs:
     steps:    
        - name: Checkout
          uses: actions/checkout@v2
-       - name: pyjarrett/setup-alire
-         uses: pyjarrett/setup-alire@latest-stable
+       - name: ada-actions/toolchain
+         uses: ada-actions/toolchain@ce2021
+         with:
+           distrib: community
+           target: native
+       - name: alire-project/setup-alire
+         uses: alire-project/setup-alire@latest-stable
        - name: Build
-         run: |
-          alr index --reset-community
-          alr config --global --set toolchain.assistant false
-          alr toolchain --install gnat_native --non-interactive
-          alr toolchain --install gprbuild --non-interactive
-          alr build --non-interactive
+         run: alr build


### PR DESCRIPTION
Still using GNAT CE 2021 to verify the build.  We're not releasing binaries with this and only using it for build checks.  It'd be nice to use the updated alr toolchain support, but I'll try again later once the github actions are updated.