### PR TITLE
Fix Is_Quoted

### DIFF
--- a/src/common/sp-strings.adb
+++ b/src/common/sp-strings.adb
@@ -194,9 +194,10 @@ package body SP.Strings is
 
     function Is_Quoted (S : String) return Boolean is
         use Ada.Characters.Latin_1;
-        Quote_Types : constant array (Positive range <>) of Character := (Quotation, Apostrophe);
     begin
-        return S'Length > 0 and then S (S'First) = S (S'Last) and then (for some X of Quote_Types => X = S (S'First));
+        return S'Length >= 2
+            and then S (S'First) in Quotation | Apostrophe
+            and then S (S'First) = S (S'Last);
     end Is_Quoted;
 
     function Split_Command (Input : ASU.Unbounded_String) return SP.Strings.String_Vectors.Vector is


### PR DESCRIPTION
String must have length of minimum 2 characters to be a quote. Compare
length with what we would like instead of comparing with what we do not
like. Simplified.